### PR TITLE
Fix slow desktop controller iteration

### DIFF
--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadControllerMonitor.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadControllerMonitor.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.utils.IntArray;
 import com.badlogic.gdx.utils.IntMap;
+import com.badlogic.gdx.controllers.desktop.JamepadControllerManager;
 import com.studiohartman.jamepad.ControllerIndex;
 import com.studiohartman.jamepad.ControllerManager;
 
@@ -28,8 +29,8 @@ public class JamepadControllerMonitor implements Runnable {
     }
 
     private void checkForNewControllers() {
-        int newNumControllers = controllerManager.getNumControllers();
-        for (int i = 0; i < newNumControllers; i++) try {
+        int numControllers = JamepadControllerManager.jamepadConfiguration.maxNumControllers;
+        for (int i = 0; i < numControllers; i++) try {
             ControllerIndex controllerIndex = controllerManager.getControllerIndex(i);
 
             if (!indexToController.containsKey(controllerIndex.getIndex()) && controllerIndex.isConnected()) {


### PR DESCRIPTION
In order to update the list of plugged-in controllers on desktop, the `JamepadControllerMonitor` iterates through Jamepad's internal list of controllers.

This works fine, but in order to get a bound in order to index that list, `ControllerManager.getNumControllers()` is called. This has performance implications: rather than returning the size of the list, `getNumControllers` probes each input device to verify it's a controller (rather than some other input device, such as a tablet pen).

On Linux, for example, this probing takes the form of an openat(), followed by several ioctl()s and a close(), for each non-contoller input device. This has a very high overhead, going back and forth with the kernel potentially many times each frame, and can tank a game's performance if these peripherals are present.

This fix simply uses `maxNumControllers` as a bounds to index into `ControllerManager`, which I think is the behavior that was intended anyway.

`ControllerManager` should also probably expose its own bounds to allow consumers to call `getControllerIndex()` safely.