### PR TITLE
Fixed gamecontrollerdb.txt failing to load with packr

### DIFF
--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
@@ -28,10 +28,8 @@ public class JamepadControllerManager extends AbstractControllerManager implemen
             if (jamepadConfiguration == null) {
                 jamepadConfiguration = new com.studiohartman.jamepad.Configuration();
             }
-            String mappingsPath = "/gamecontrollerdb.txt";
 
-
-            controllerManager = new com.studiohartman.jamepad.ControllerManager(jamepadConfiguration, mappingsPath);
+            controllerManager = new com.studiohartman.jamepad.ControllerManager(jamepadConfiguration);
             controllerManager.initSDLGamepad();
 
             JamepadControllerMonitor monitor = new JamepadControllerMonitor(controllerManager, compositeListener);

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
@@ -28,7 +28,7 @@ public class JamepadControllerManager extends AbstractControllerManager implemen
             if (jamepadConfiguration == null) {
                 jamepadConfiguration = new com.studiohartman.jamepad.Configuration();
             }
-            String mappingsPath = "gamecontrollerdb.txt";
+            String mappingsPath = "/gamecontrollerdb.txt";
 
 
             controllerManager = new com.studiohartman.jamepad.ControllerManager(jamepadConfiguration, mappingsPath);


### PR DESCRIPTION
Fixed issue #13 by adding the slash at the beginning of the mapping file, which is needed for proper loading of the classpath resource.