### PR TITLE
Android: improved default mappings for controller axis input

### DIFF
--- a/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
+++ b/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
@@ -28,7 +28,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntIntMap;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.UUID;
 
 public class AndroidController implements Controller {
@@ -65,26 +64,30 @@ public class AndroidController implements Controller {
 		//remove pov axis as it will be mapped to buttons
 		if (axesIDList.contains(MotionEvent.AXIS_HAT_X) && axesIDList.contains(MotionEvent.AXIS_HAT_Y)){
 			povAxis = true;
-			axesIDList.remove(MotionEvent.AXIS_HAT_X);
-			axesIDList.remove(MotionEvent.AXIS_HAT_Y);
+			axesIDList.remove((Integer)MotionEvent.AXIS_HAT_X);
+			axesIDList.remove((Integer)MotionEvent.AXIS_HAT_Y);
 		}
 
 		if (AndroidControllers.useNewAxisLogic){
 			//remove trigger axis as it will be mapped to buttons
 			if (axesIDList.contains(MotionEvent.AXIS_LTRIGGER) && axesIDList.contains(MotionEvent.AXIS_RTRIGGER)){
 				triggerAxis = true;
-				axesIDList.remove(MotionEvent.AXIS_LTRIGGER);
-				axesIDList.remove(MotionEvent.AXIS_RTRIGGER);
+				axesIDList.remove((Integer)MotionEvent.AXIS_LTRIGGER);
+				axesIDList.remove((Integer)MotionEvent.AXIS_RTRIGGER);
 			}
 
 			//move left and right sticks to indices 0-3, to match default controller mapping
 			if (axesIDList.contains(MotionEvent.AXIS_X) && axesIDList.contains(MotionEvent.AXIS_Y)){
-				axesIDList.add(0, axesIDList.remove(MotionEvent.AXIS_X));
-				axesIDList.add(1, axesIDList.remove(MotionEvent.AXIS_Y));
+				axesIDList.remove((Integer)MotionEvent.AXIS_X);
+				axesIDList.remove((Integer)MotionEvent.AXIS_Y);
+				axesIDList.add(0, MotionEvent.AXIS_X);
+				axesIDList.add(1, MotionEvent.AXIS_Y);
 			}
 			if (axesIDList.contains(MotionEvent.AXIS_Z) && axesIDList.contains(MotionEvent.AXIS_RZ)){
-				axesIDList.add(2, axesIDList.remove(MotionEvent.AXIS_Z));
-				axesIDList.add(3, axesIDList.remove(MotionEvent.AXIS_RZ));
+				axesIDList.remove((Integer)MotionEvent.AXIS_Z);
+				axesIDList.remove((Integer)MotionEvent.AXIS_RZ);
+				axesIDList.add(2, MotionEvent.AXIS_Z);
+				axesIDList.add(3, MotionEvent.AXIS_RZ);
 			}
 		}
 

--- a/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
+++ b/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidController.java
@@ -39,6 +39,9 @@ public class AndroidController implements Controller {
 	protected float povX = 0f;
 	protected float povY = 0f;
 	private boolean povAxis;
+	protected float lTrigger = 0f;
+	protected float rTrigger = 0f;
+	private boolean triggerAxis;
 	private final Array<ControllerListener> listeners = new Array<ControllerListener>();
 	private String uuid;
 	public boolean connected;
@@ -53,10 +56,12 @@ public class AndroidController implements Controller {
 		int numAxes = 0;
 		for (MotionRange range : device.getMotionRanges()) {
 			if ((range.getSource() & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
-				if (range.getAxis() != MotionEvent.AXIS_HAT_X && range.getAxis() != MotionEvent.AXIS_HAT_Y) {
-					numAxes += 1;
-				} else {
+				if (range.getAxis() == MotionEvent.AXIS_HAT_X || range.getAxis() == MotionEvent.AXIS_HAT_Y){
 					povAxis = true;
+				} else if (range.getAxis() == MotionEvent.AXIS_LTRIGGER || range.getAxis() == MotionEvent.AXIS_RTRIGGER){
+					triggerAxis = true;
+				} else  {
+					numAxes += 1;
 				}
 			}
 		}
@@ -66,11 +71,32 @@ public class AndroidController implements Controller {
 		int i = 0;
 		for (MotionRange range : device.getMotionRanges()) {
 			if ((range.getSource() & InputDevice.SOURCE_CLASS_JOYSTICK) != 0) {
-				if (range.getAxis() != MotionEvent.AXIS_HAT_X && range.getAxis() != MotionEvent.AXIS_HAT_Y) {
+				if (range.getAxis() != MotionEvent.AXIS_HAT_X && range.getAxis() != MotionEvent.AXIS_HAT_Y
+					&& range.getAxis() != MotionEvent.AXIS_LTRIGGER && range.getAxis() != MotionEvent.AXIS_RTRIGGER) {
 					axesIds[i++] = range.getAxis();
 				}
 			}
 		}
+
+		//attempt to place left and right sticks in indices 0-3, to match default controller mapping
+		i = 0;
+		for (int id : axesIds){
+			if (id == MotionEvent.AXIS_X && i != 0){
+				axesIds[i] = axesIds[0];
+				axesIds[0] = id;
+			} else if (id == MotionEvent.AXIS_Y && i != 1){
+				axesIds[i] = axesIds[1];
+				axesIds[1] = id;
+			} else if (id == MotionEvent.AXIS_Z && i != 2){
+				axesIds[i] = axesIds[2];
+				axesIds[2] = id;
+			} else if (id == MotionEvent.AXIS_RZ && i != 3){
+				axesIds[i] = axesIds[3];
+				axesIds[3] = id;
+			}
+			i++;
+		}
+
 	}
 
 	public boolean isAttached () {
@@ -79,6 +105,10 @@ public class AndroidController implements Controller {
 
 	public boolean hasPovAxis() {
 		return povAxis;
+	}
+
+	public boolean hasTriggerAxis(){
+		return triggerAxis;
 	}
 
 	public void setAttached (boolean attached) {

--- a/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -36,6 +36,7 @@ import com.badlogic.gdx.utils.Pool;
 public class AndroidControllers extends AbstractControllerManager implements LifecycleListener, OnKeyListener, OnGenericMotionListener {
 	private final static String TAG = "AndroidControllers";
 	public static boolean ignoreNoGamepadButtons = true;
+	public static boolean useNewAxisLogic = true;
 	private final IntMap<AndroidController> controllerMap = new IntMap<AndroidController>();
 	private final Array<ControllerListener> listeners = new Array<ControllerListener>();
 	private final Array<AndroidControllerEvent> eventQueue = new Array<AndroidControllerEvent>();

--- a/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
+++ b/gdx-controllers-android/src/com/badlogic/gdx/controllers/android/AndroidControllers.java
@@ -200,6 +200,47 @@ public class AndroidControllers extends AbstractControllerManager implements Lif
 					}
 				}
 
+				if (controller.hasTriggerAxis()){
+					float lTrigger = motionEvent.getAxisValue(MotionEvent.AXIS_LTRIGGER);
+					float rTrigger = motionEvent.getAxisValue(MotionEvent.AXIS_RTRIGGER);
+					//map axis movement to trigger buttons
+					if (lTrigger != controller.lTrigger){
+						if (lTrigger == 1){
+							AndroidControllerEvent event = eventPool.obtain();
+							event.controller = controller;
+							event.type = AndroidControllerEvent.BUTTON_DOWN;
+							event.code = KeyEvent.KEYCODE_BUTTON_L2;
+							eventQueue.add(event);
+						} else if (lTrigger == 0){
+							AndroidControllerEvent event = eventPool.obtain();
+							event.controller = controller;
+							event.type = AndroidControllerEvent.BUTTON_UP;
+							event.code = KeyEvent.KEYCODE_BUTTON_L2;
+							eventQueue.add(event);
+						}
+						controller.lTrigger = lTrigger;
+
+					}
+
+					if (rTrigger != controller.rTrigger){
+						if (rTrigger == 1){
+							AndroidControllerEvent event = eventPool.obtain();
+							event.controller = controller;
+							event.type = AndroidControllerEvent.BUTTON_DOWN;
+							event.code = KeyEvent.KEYCODE_BUTTON_R2;
+							eventQueue.add(event);
+						} else if (rTrigger == 0){
+							AndroidControllerEvent event = eventPool.obtain();
+							event.controller = controller;
+							event.type = AndroidControllerEvent.BUTTON_UP;
+							event.code = KeyEvent.KEYCODE_BUTTON_R2;
+							eventQueue.add(event);
+						}
+						controller.rTrigger = rTrigger;
+
+					}
+				}
+
 				int axisIndex = 0;
             	for (int axisId: controller.axesIds) {
 					float axisValue = motionEvent.getAxisValue(axisId);
@@ -229,6 +270,10 @@ public class AndroidControllers extends AbstractControllerManager implements Lif
 		AndroidController controller = controllerMap.get(keyEvent.getDeviceId());
 		if(controller != null) {
 			if(controller.getButton(keyCode) && keyEvent.getAction() == KeyEvent.ACTION_DOWN) {
+				return true;
+			}
+			//ignore any button trigger input if there is a trigger axis
+			if (controller.hasTriggerAxis() && (keyCode == KeyEvent.KEYCODE_BUTTON_L2 || keyCode == KeyEvent.KEYCODE_BUTTON_R2)){
 				return true;
 			}
 			synchronized(eventQueue) {


### PR DESCRIPTION
While this isn't a complete replacement to the 'prompt the user to map their controller manually' advice, I've made some adjustments to axis logic that should allow for Android controllers to work with the default mapping in a bunch more cases. These changes are based on Android's guide for handling controller actions: https://developer.android.com/training/game-controllers/controller-input.html#button

- now tries to ensure that AXIS_X, AXIS_Y, AXIS_R, and AXIS_RZ are mapped to ids 0,1,2, and 3 regardless of where they appear in the motion range list. This ensures consistency with iOS and Desktop in most cases.
- identifies if the L2 and R2 buttons are using an axis, and automatically maps them to button inputs just like it already does with the POV axis. If they do have an axis then the buttons themselves are ignored

On my Android 11 device this totally fixed default mapping issues for a PS4 and Xbox One controller. A Switch pro controller already worked before and after. Lastly there were improvements with a PS5 controller and a 3rd party Switch controller, but button mappings were still wrong. The button mappings apparently are an Android 11 issue which is fixed in 12 though: https://stackoverflow.com/questions/68190869/dualshock-5-and-android

This should probably be considered a breaking change, as existing customized mappings might be incorrect with these axis changes.