### PR TITLE
Improvements to hotplugging on Desktop.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
         appName = 'gdx-controllers'
         gdxVersion = '1.9.11'
         roboVMVersion = '2.3.16'
-        jamepadVersion = '2.0.20.0'
+        jamepadVersion = '2.26.4.0-SNAPSHOT'
 
         isReleaseBuild = {
             return project.hasProperty("RELEASE")

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/JamepadControllerManager.java
@@ -36,7 +36,6 @@ public class JamepadControllerManager extends AbstractControllerManager implemen
             monitor.run();
 
             Gdx.app.addLifecycleListener(new JamepadShutdownHook(controllerManager));
-            Gdx.app.postRunnable(monitor);
 
             nativeLibInitialized = true;
         }

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadControllerMonitor.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadControllerMonitor.java
@@ -2,69 +2,107 @@ package com.badlogic.gdx.controllers.desktop.support;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.controllers.ControllerListener;
-import com.badlogic.gdx.utils.IntArray;
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.controllers.desktop.JamepadControllerManager;
 import com.studiohartman.jamepad.ControllerIndex;
 import com.studiohartman.jamepad.ControllerManager;
+import com.studiohartman.jamepad.ControllerUnpluggedException;
 
 public class JamepadControllerMonitor implements Runnable {
     private final ControllerManager controllerManager;
     private final ControllerListener listener;
-    private final IntMap<Tuple> indexToController = new IntMap<>();
-    //temporary array for cleaning disconnected controllers
-    private final IntArray disconnectedControllers = new IntArray();
+    private final IntMap<Tuple> indexToController
+        = new IntMap<>(JamepadControllerManager.jamepadConfiguration.maxNumControllers);
+    // temporary array for delaying connect messages
+    private final Array<JamepadController> connectedControllers = new Array<JamepadController>();
 
     public JamepadControllerMonitor(ControllerManager controllerManager, ControllerListener listener) {
         this.controllerManager = controllerManager;
         this.listener = listener;
+
+        reconcileControllers();
     }
 
     @Override
     public void run() {
-        controllerManager.update();
+        boolean controllersChanged = controllerManager.update();
 
-        checkForNewControllers();
+        if (controllersChanged) {
+            reconcileControllers();
+        }
+
         update();
 
         Gdx.app.postRunnable(this);
     }
 
-    private void checkForNewControllers() {
+    private void reconcileControllers() {
+        // Break old connections to help detect disconnected objects later.
+        for (Tuple tuple : indexToController.values()) {
+            JamepadController controller = tuple.controller;
+            tuple.index = null;
+            controller.setControllerIndex(null);
+        }
+
+        // Get already-connected controllers paired with their existing objects.
+        // Create objects for new controllers, but don't send connect messages yet.
+        connectedControllers.clear();
         int numControllers = JamepadControllerManager.jamepadConfiguration.maxNumControllers;
         for (int i = 0; i < numControllers; i++) try {
             ControllerIndex controllerIndex = controllerManager.getControllerIndex(i);
-
-            if (!indexToController.containsKey(controllerIndex.getIndex()) && controllerIndex.isConnected()) {
-                Tuple tuple1 = new Tuple(controllerIndex);
-                tuple1.controller.addListener(listener);
-
-                indexToController.put(controllerIndex.getIndex(), tuple1);
-                listener.connected(tuple1.controller);
+            try {
+                int instanceID = controllerIndex.getDeviceInstanceID();
+                if (indexToController.containsKey(instanceID)) {
+                    // Pre-existing controller, pair with existing object.
+                    Tuple tuple1 = indexToController.get(instanceID);
+                    tuple1.index = controllerIndex;
+                    tuple1.controller.setControllerIndex(controllerIndex);
+                } else {
+                    // New controller. Create new object, and store it for connect message later.
+                    Tuple tuple1 = new Tuple(controllerIndex);
+                    indexToController.put(instanceID, tuple1);
+                    connectedControllers.add(tuple1.controller);
+                }
+            } catch (ControllerUnpluggedException e) {
+                // controller not connected, no need to pair it
             }
         } catch (ArrayIndexOutOfBoundsException t) {
             // more controllers connected than we can handle according to our config
         }
+
+        // Remove disconnected objects.
+        IntMap.Values<Tuple> values = indexToController.values();
+        while (values.hasNext()) {
+            Tuple tuple = values.next();
+            if (tuple.index == null) {
+                tuple.controller.setDisconnected();
+                values.remove();
+            }
+        }
+
+        // Set up listeners for new controllers and send connect messages.
+        for (JamepadController controller: connectedControllers) {
+            controller.addListener(listener);
+            listener.connected(controller);
+        }
     }
 
     private void update() {
-        disconnectedControllers.clear();
-        for (Tuple tuple : indexToController.values()) {
+        IntMap.Values<Tuple> values = indexToController.values();
+        while (values.hasNext()) {
+            Tuple tuple = values.next();
             JamepadController controller = tuple.controller;
             boolean connected = controller.update();
 
             if (!connected) {
-                disconnectedControllers.add(tuple.index.getIndex());
+                values.remove();
             }
-        }
-
-        for (int i = 0; i < disconnectedControllers.size; i++) {
-            indexToController.remove(disconnectedControllers.get(i));
         }
     }
 
     private class Tuple {
-        public final ControllerIndex index;
+        public ControllerIndex index;
         public final JamepadController controller;
 
         public Tuple(ControllerIndex index) {

--- a/test/core/src/main/java/com/badlogic/gdx/controllers/test/ControllersTest.java
+++ b/test/core/src/main/java/com/badlogic/gdx/controllers/test/ControllersTest.java
@@ -76,8 +76,6 @@ public class ControllersTest extends ApplicationAdapter {
             }
         };
 
-        refreshControllersList();
-
         Controllers.addListener(new ControllerAdapter() {
             @Override
             public void connected(final Controller controller) {
@@ -226,6 +224,8 @@ public class ControllersTest extends ApplicationAdapter {
         stage.addActor(table);
 
         Gdx.input.setInputProcessor(stage);
+
+        refreshControllersList();
     }
 
     private void addAxisLabels() {
@@ -293,6 +293,9 @@ public class ControllersTest extends ApplicationAdapter {
             if (name.length() > 30)
                 name = name.substring(0, 28) + "...";
             controllerNames.add(name);
+
+            // avoid adding the listener to the same controller twice
+            controller.removeListener(controllerListener);
             controller.addListener(controllerListener);
         }
         controllerList.setItems(controllerNames);


### PR DESCRIPTION
Fixes #29

I was only able to test these changes on Windows 7, so I recommend testing on other major operating systems. There is no change to non-Desktop platforms except a few changes to the test app.

Below I will annotate my commit message with information about each change. I'm open to suggestions if you disagree with any of them.

### JamepadControllerMonitor
This is the most heavily changed file, with most of the important changes.

> Changes JamepadControllerMonitor to track controllers by SDL instance ID instead of SDL index. This keeps the association of Controller java objects and physical devices constant.

`checkForNewControllers()` has been replaced by `reconcileControllers()`. In addition to connecting new controllers, this method also removes disconnected controllers, and reassigns `ControllerIndex` objects between `JamepadController`s to keep them paired with the same physical device.

> Cuts out the check for new controllers in JamepadControllerMonitor by instead updating the controller list when Jamepad reports that its controller list was updated.

`reconcileControllers()` does not check if the controller list need to be updated like `checkForNewControllers()` did. Instead, we check the new return value of `controllerManager.update()`, which tells us when Jamepad's list was updated. I believe this should always detect when changes are needed, but we find that it doesn't, we could write a new test.

Other notes:

`JamepadControllerMonitor`'s `update()` method still tries to disconnect controllers the old way, though in practice, `reconcileControllers()` should handle it most of the time. `update()` already implicitly used an iterator, so I've made that iterator explicit so we can use it's `remove()` method, avoiding the need for a temporary array here. The same structure is used in `reconcileControllers()`.

A new temporary array is used when connecting new controllers. Sending out a `connect()` event while the controller list is being reconstructed can cause issues, as it gives the user a chance to call methods on the other controllers, which may be in an incomplete state. Instead, we store the new controller and set up its listener at the end.

`reconcileControllers()` is now called in the constructor to set up the initial state. This introduces the restriction that `controllerManager.initSDLGamepad()` must be called before the constructor, but it already was.

`Tuple`'s `ControllerIndex` is no longer final. This is necessary to update the controller pairings.

The `IntMap` of controllers now uses the Jamepad `Configuration`'s `maxNumControllers` as an initial capacity. This is a minor optimization. We iterate through the list much more often than we search it, so the smaller size will likely be better. It will now usually have a backing array size of 8 instead of 64.

### JamepadController

> Adds the ability for JamepadController to report its name when disconnected by storing the name on connect.

The committed implementation polls and stores the name in the constructor, continues to poll (but not store) the name while connected, then returns the stored name when disconnected. If we are confident that the name won't change, we could instead always report the stored name. If we are worried the name will change, we could poll and store the name each time while connected.

> Allows JampadController to treat a null ControllerIndex as a disconnected controller.

The `ControllerIndex` that the controller was using may be in use by another, still-connected controller, so being able to function without one is safest. For this reason, every method that caught a `ControllerUnpluggedException` now also catches `NullPointerException` and treats them the same way.

Other notes:

`setDisconnected()` is now public so `reconcileControllers()` can proactively disconnect controllers. When used this way, its `ControllerIndex` will be null, and it will skip logging that it failed to query it (since that didn't happen).

The `controllerIndex` variable is no longer final, and there is a new method (`setControllerIndex`) to assign it.

### JamepadControllerManager

> Fixes a bug in JamepadControllerManager that caused the controller update code to run twice as often as intended.

The call to `Gdx.app.postRunnable(monitor)` was removed. The call to `monitor.run()` 2 lines earlier ends by adding the monitor to the list of runnables. Adding it again caused it to be in the list twice, so it would run twice back-to-back each frame, which was unnecessary.

### ControllersTest

> Fixes a bug in ControllersTest that caused the first controller to be unresponsive when the program first starts.

`refreshControllersList()` was called fairly early in `create()`, before some listeners were set up. Moving it to the end of `create()` doesn't seem to cause problems, and gives a more complete state at startup.

> Fixes a bug in ControllersTest that caused duplicate disconnect messages in some circumstances.

The listener was added to each controller each time `refreshControllersList()` was called. This could result in the listener being added to the same controller many times, resulting in many disconnect events when disconnected. Attempting to remove the listener before adding it prevents this.

### build.gradle

> Updates to the newest snapshot of Jamepad.

Updates to Jamepad's API are used here.