### PR TITLE
Updates Github actions.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,15 +13,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Setup Android build environment
-      uses: android-actions/setup-android@v2.0.2
     - name: Build Android
       run: ./gradlew clean :test:android:buildDebug
     - name: Build Desktop

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,15 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Setup Android build environment
-      uses: android-actions/setup-android@v2.0.2
     - name: Build Android
       run: ./gradlew clean :test:android:buildDebug
     - name: Build Desktop
@@ -29,9 +28,9 @@ jobs:
       run: ./gradlew :test:html:build
     - name: Import GPG key
       id: import_gpg
-      uses: crazy-max/ghaction-import-gpg@1c6a9e9d3594f2d743f1b1dd7669ab0dfdffa922
+      uses: crazy-max/ghaction-import-gpg@v5
       with:
-        gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
         passphrase: ${{ secrets.GPG_PASSPHRASE }}
     - name: Release build deploy
       env:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -11,15 +11,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 8
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Setup Android build environment
-      uses: android-actions/setup-android@v2.0.2
     - name: Build Android
       run: ./gradlew clean :test:android:buildDebug
     - name: Build Desktop


### PR DESCRIPTION
Older versions used deprecated features.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Removes action to set up Android environment, instead relying on the runner's pre-installed Android environment.