### PR TITLE
Reduce garbage produced every update

### DIFF
--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/FloatWrapper.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/FloatWrapper.java
@@ -1,5 +1,0 @@
-package com.badlogic.gdx.controllers.desktop.support;
-
-public class FloatWrapper {
-    public float value;
-}

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/FloatWrapper.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/FloatWrapper.java
@@ -1,0 +1,5 @@
+package com.badlogic.gdx.controllers.desktop.support;
+
+public class FloatWrapper {
+    public float value;
+}

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.ControllerMapping;
 import com.badlogic.gdx.controllers.ControllerPowerLevel;
+import com.badlogic.gdx.utils.IntFloatMap;
 import com.badlogic.gdx.utils.IntMap;
 import com.badlogic.gdx.utils.Logger;
 import com.badlogic.gdx.utils.TimeUtils;
@@ -33,7 +34,7 @@ public class JamepadController implements Controller {
 
     private final CompositeControllerListener compositeControllerListener = new CompositeControllerListener();
     private final IntMap<Boolean> buttonState = new IntMap<>();
-    private final IntMap<FloatWrapper> axisState = new IntMap<>();
+    private final IntFloatMap axisState = new IntFloatMap();
     private final String uuid;
     private final String name;
     private ControllerIndex controllerIndex;
@@ -134,14 +135,13 @@ public class JamepadController implements Controller {
             int id = axis.ordinal();
 
             float value = getAxis(id);
-            FloatWrapper axisValueWrapper = axisState.get(id);
-            if (value != axisValueWrapper.value) {
+            if (value != axisState.get(id, 0)) {
                 if (logger.getLevel() == Logger.DEBUG) {
                     logger.debug("Axis [" + id + " - " + toAxis(id) + "] moved [" + value + "]");
                 }
                 compositeControllerListener.axisMoved(this, id, value);
             }
-            axisValueWrapper.value = value;
+            axisState.put(id, value);
         }
     }
 
@@ -167,7 +167,7 @@ public class JamepadController implements Controller {
 
     private void initializeState() {
         for (ControllerAxis axis : ControllerAxis.values()) {
-            axisState.put(axis.ordinal(), new FloatWrapper());
+            axisState.put(axis.ordinal(), 0);
         }
 
         for (ControllerButton button : ControllerButton.values()) {

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
@@ -19,15 +19,16 @@ public class JamepadController implements Controller {
     private static final IntMap<ControllerButton> CODE_TO_BUTTON = new IntMap<>(ControllerButton.values().length);
     private static final IntMap<ControllerAxis> CODE_TO_AXIS = new IntMap<>(ControllerAxis.values().length);
     private static final Logger logger = new Logger(JamepadController.class.getSimpleName());
+    // ControllerButton.values() and ControllerAxis.values() is cached once, to avoid producing garbage every frame
     private static final ControllerButton[] CONTROLLER_BUTTON_VALUES = ControllerButton.values();
     private static final ControllerAxis[] CONTROLLER_AXIS_VALUES = ControllerAxis.values();
 
     static {
-        for (ControllerButton button : ControllerButton.values()) {
+        for (ControllerButton button : CONTROLLER_BUTTON_VALUES) {
             CODE_TO_BUTTON.put(button.ordinal(), button);
         }
 
-        for (ControllerAxis axis : ControllerAxis.values()) {
+        for (ControllerAxis axis : CONTROLLER_AXIS_VALUES) {
             CODE_TO_AXIS.put(axis.ordinal(), axis);
         }
     }
@@ -166,11 +167,11 @@ public class JamepadController implements Controller {
     }
 
     private void initializeState() {
-        for (ControllerAxis axis : ControllerAxis.values()) {
+        for (ControllerAxis axis : CONTROLLER_AXIS_VALUES) {
             axisState.put(axis.ordinal(), 0);
         }
 
-        for (ControllerButton button : ControllerButton.values()) {
+        for (ControllerButton button : CONTROLLER_BUTTON_VALUES) {
             buttonState.put(button.ordinal(), false);
         }
     }

--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
@@ -18,6 +18,8 @@ public class JamepadController implements Controller {
     private static final IntMap<ControllerButton> CODE_TO_BUTTON = new IntMap<>(ControllerButton.values().length);
     private static final IntMap<ControllerAxis> CODE_TO_AXIS = new IntMap<>(ControllerAxis.values().length);
     private static final Logger logger = new Logger(JamepadController.class.getSimpleName());
+    private static final ControllerButton[] CONTROLLER_BUTTON_VALUES = ControllerButton.values();
+    private static final ControllerAxis[] CONTROLLER_AXIS_VALUES = ControllerAxis.values();
 
     static {
         for (ControllerButton button : ControllerButton.values()) {
@@ -31,7 +33,7 @@ public class JamepadController implements Controller {
 
     private final CompositeControllerListener compositeControllerListener = new CompositeControllerListener();
     private final IntMap<Boolean> buttonState = new IntMap<>();
-    private final IntMap<Float> axisState = new IntMap<>();
+    private final IntMap<FloatWrapper> axisState = new IntMap<>();
     private final String uuid;
     private final String name;
     private ControllerIndex controllerIndex;
@@ -128,22 +130,23 @@ public class JamepadController implements Controller {
     }
 
     private void updateAxisState() {
-        for (ControllerAxis axis : ControllerAxis.values()) {
+        for (ControllerAxis axis : CONTROLLER_AXIS_VALUES) {
             int id = axis.ordinal();
 
             float value = getAxis(id);
-            if (value != axisState.get(id)) {
+            FloatWrapper axisValueWrapper = axisState.get(id);
+            if (value != axisValueWrapper.value) {
                 if (logger.getLevel() == Logger.DEBUG) {
                     logger.debug("Axis [" + id + " - " + toAxis(id) + "] moved [" + value + "]");
                 }
                 compositeControllerListener.axisMoved(this, id, value);
             }
-            axisState.put(id, value);
+            axisValueWrapper.value = value;
         }
     }
 
     private void updateButtonsState() {
-        for (ControllerButton button : ControllerButton.values()) {
+        for (ControllerButton button : CONTROLLER_BUTTON_VALUES) {
             int id = button.ordinal();
 
             boolean pressed = getButton(id);
@@ -164,7 +167,7 @@ public class JamepadController implements Controller {
 
     private void initializeState() {
         for (ControllerAxis axis : ControllerAxis.values()) {
-            axisState.put(axis.ordinal(), 0.0f);
+            axisState.put(axis.ordinal(), new FloatWrapper());
         }
 
         for (ControllerButton button : ControllerButton.values()) {


### PR DESCRIPTION
Hi, after some profiling found that this library produces quite some garbage every frame/update. 

- so what I did is to cache `ControllerButton.values()` and `ControllerAxis.values()` for the update methods, since those were creating new arrays all the time. (some JVMs might be able to correctly optimize this, but the one I profiled did not)
- also the line `axisState.put(id, value);` was causing the values to be boxed to new `Float`s every update, so I introduced a simple wrapper class with a mutable float, which does not create any garbage

This only covers the desktop version, similar optimizations could be made for other platforms probably.

IDK if this can be merged as-is, but would love to hear about any suggestions or doubts.