### PR TITLE
Fix NPE if canVibrate fails due to controller unplugged

### DIFF
--- a/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
+++ b/gdx-controllers-desktop/src/main/java/com/badlogic/gdx/controllers/desktop/support/JamepadController.java
@@ -183,6 +183,7 @@ public class JamepadController implements Controller {
                 canVibrate = controllerIndex.canVibrate();
             } catch (ControllerUnpluggedException | NullPointerException e) {
                 setDisconnected();
+                return false;
             }
         }
 


### PR DESCRIPTION
`canVibrate` would be null when reaching the catch block, but it will fall through the return statement, leading to a NPE.

Fixes https://github.com/libgdx/gdx-controllers/issues/44