### PR TITLE
Fix potential null name on iOS

### DIFF
--- a/gdx-controllers-ios/src/com/badlogic/gdx/controllers/IosController.java
+++ b/gdx-controllers-ios/src/com/badlogic/gdx/controllers/IosController.java
@@ -346,7 +346,10 @@ public class IosController extends AbstractController {
 
     @Override
     public String getName() {
-        return controller.getVendorName();
+        String vendorName = controller.getVendorName();
+        if (vendorName == null)
+            return "Unnamed Controller";
+        return vendorName;
     }
 
     @Override


### PR DESCRIPTION
`vendorName` is nullable: https://developer.apple.com/documentation/gamecontroller/gcdevice/vendorname?language=objc

This aligns the iOS behaviour with the other backends (at least with the desktop backend).

Or maybe it should be made nullable and handling be left to the user, who can localise the "Unknown Controller" string.